### PR TITLE
Fix query condition to be from the correct level in hierarchy

### DIFF
--- a/src/QueryBuilderParser/JoinSupportingQueryBuilderParser.php
+++ b/src/QueryBuilderParser/JoinSupportingQueryBuilderParser.php
@@ -40,10 +40,11 @@ class JoinSupportingQueryBuilderParser extends QueryBuilderParser{
      *
      * @param Builder $query
      * @param stdClass $rule
+     * @param String $condition
      * @return Builder
      * @throws QBParseException
      */
-    protected function makeQuery(Builder $query, stdClass $rule)
+    protected function makeQuery(Builder $query, stdClass $rule, $condition)
     {
         /**
          * Make sure most of the common fields from the QueryBuilder have been added.
@@ -114,13 +115,13 @@ class JoinSupportingQueryBuilderParser extends QueryBuilderParser{
                   } else {
                       $q->where($subclause['to_value_column'], $subclause['operator'], $subclause['value']);
                   }
-            },'and',$not);
+            },$condition,$not);
 
         } else {
             if ($require_array) {
-                $query = $this->makeQueryWhenArray($query, $rule, $_sql_op, $value);
+                $query = $this->makeQueryWhenArray($query, $rule, $_sql_op, $value, $condition);
             } else {
-                $query = $query->where($rule->field, $_sql_op['operator'], $value);
+                $query = $query->where($rule->field, $_sql_op['operator'], $value, $condition);
             }
         }
         return $query;

--- a/tests/QueryBuilderParserTest.php
+++ b/tests/QueryBuilderParserTest.php
@@ -82,7 +82,7 @@ class QueryBuilderParserTest extends \PHPUnit_Framework_TestCase
 
         $test = $qb->parse($this->json1, $builder);
 
-        $this->assertEquals('select * where `price` < ? OR (`name` LIKE ? and `name` = ?)', $builder->toSql());
+        $this->assertEquals('select * where `price` < ? and (`name` LIKE ? or `name` = ?)', $builder->toSql());
     }
 
     public function testBetterThenTheLastTime()
@@ -93,7 +93,7 @@ class QueryBuilderParserTest extends \PHPUnit_Framework_TestCase
         $json = '{"condition":"AND","rules":[{"id":"anchor_text","field":"anchor_text","type":"string","input":"text","operator":"contains","value":"www"},{"condition":"OR","rules":[{"id":"citation_flow","field":"citation_flow","type":"double","input":"text","operator":"greater_or_equal","value":"30"},{"id":"trust_flow","field":"trust_flow","type":"double","input":"text","operator":"greater_or_equal","value":"30"}]}]}';
         $test = $qb->parse($json, $builder);
 
-        $this->assertEquals('select * where `anchor_text` LIKE ? OR (`citation_flow` >= ? and `trust_flow` >= ?)', $builder->toSql());
+        $this->assertEquals('select * where `anchor_text` LIKE ? and (`citation_flow` >= ? or `trust_flow` >= ?)', $builder->toSql());
     }
 
     private function makeJSONForInNotInTest($is_in = true)
@@ -140,7 +140,7 @@ class QueryBuilderParserTest extends \PHPUnit_Framework_TestCase
 
         $qb->parse($this->makeJSONForInNotInTest(), $builder);
 
-        $this->assertEquals('select * where `price` < ? OR (`category` in (?, ?))', $builder->toSql());
+        $this->assertEquals('select * where `price` < ? and (`category` in (?, ?))', $builder->toSql());
     }
 
     public function testCategoryNotIn()
@@ -150,7 +150,7 @@ class QueryBuilderParserTest extends \PHPUnit_Framework_TestCase
 
         $qb->parse($this->makeJSONForInNotInTest(false), $builder);
 
-        $this->assertEquals('select * where `price` < ? OR (`category` not in (?, ?))', $builder->toSql());
+        $this->assertEquals('select * where `price` < ? and (`category` not in (?, ?))', $builder->toSql());
     }
 
     public function testManyNestedQuery()
@@ -213,7 +213,7 @@ class QueryBuilderParserTest extends \PHPUnit_Framework_TestCase
 
         $qb->parse($json, $builder);
 
-        $this->assertEquals('select * where `price` < ? AND (`category` in (?, ?) OR (`name` = ? AND (`name` = ?)))', $builder->toSql());
+        $this->assertEquals('select * where `price` < ? and (`category` in (?, ?) and (`name` = ? or (`name` = ?)))', $builder->toSql());
         //$this->assertEquals('/* This test currently fails. This should be fixed. */', $builder->toSql());
 
     }

--- a/tests/QueryBuilderParserTest.php
+++ b/tests/QueryBuilderParserTest.php
@@ -218,6 +218,71 @@ class QueryBuilderParserTest extends \PHPUnit_Framework_TestCase
 
     }
 
+    public function testManyNestedQueryWithOr()
+    {
+        // $('#builder-basic').queryBuilder('setRules', /** This object */);
+        $json = '{
+           "condition":"OR",
+           "rules":[
+              {
+                 "id":"price",
+                 "field":"price",
+                 "type":"double",
+                 "input":"text",
+                 "operator":"less",
+                 "value":"10.25"
+              }, {
+                 "condition":"OR",
+                 "rules":[
+                    {
+                       "id":"category",
+                       "field":"category",
+                       "type":"integer",
+                       "input":"select",
+                       "operator":"in",
+                       "value":[
+                          "1", "2"
+                       ]
+                    }, {
+                       "condition":"AND",
+                       "rules":[
+                          {
+                             "id":"name",
+                             "field":"name",
+                             "type":"string",
+                             "input":"text",
+                             "operator":"equal",
+                             "value":"dgfssdfg"
+                          }, {
+                             "condition":"AND",
+                             "rules":[
+                                {
+                                   "id":"name",
+                                   "field":"name",
+                                   "type":"string",
+                                   "input":"text",
+                                   "operator":"equal",
+                                   "value":"sadf"
+                                }
+                             ]
+                          }
+                       ]
+                    }
+                 ]
+              }
+           ]
+        }';
+
+        $builder = $this->createQueryBuilder();
+        $qb = $this->getParserUnderTest();
+
+        $qb->parse($json, $builder);
+
+        $this->assertEquals('select * where `price` < ? or (`category` in (?, ?) or (`name` = ? and (`name` = ?)))', $builder->toSql());
+        //$this->assertEquals('/* This test currently fails. This should be fixed. */', $builder->toSql());
+
+    }
+
     /**
      * @expectedException \timgws\QBParseException
      */


### PR DESCRIPTION
Fix query condition so it is applied from the correct level in the QueryBuilder hierarchy.
See https://github.com/timgws/QueryBuilderParser/issues/5 for details
